### PR TITLE
Set use_proxy to no for get_url

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,7 @@
   get_url:
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/jnlpJars/jenkins-cli.jar"
     dest: "{{ jenkins_jar_location }}"
+    use_proxy: no
   register: jarfile_get
   until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"
   retries: 5


### PR DESCRIPTION
get_url may fail due to connection issue when
http(s) proxy is used, setting use_proxy to no.

Signed-off-by: zshi <zshi@redhat.com>